### PR TITLE
feat: Add GitHub stars display in Navbar and implement useGitHubStars…

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -7,6 +7,7 @@ import { useThemeContext } from "@/providers/ThemeProvider";
 import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { getComponentList } from "@/config/docs";
+import { useGitHubStars } from "@/hooks/useGitHubStars";
 
 // Organize components into categories
 function getComponentsMenu() {
@@ -139,6 +140,7 @@ export function Navbar() {
   const [isSearchVisible, setIsSearchVisible] = useState(false);
   const [isThemeTransitioning, setIsThemeTransitioning] = useState(false);
   const [isSearchExpanded, setIsSearchExpanded] = useState(false);
+  const { stars } = useGitHubStars("https://github.com/w3-kit/ui");
 
   // Preloaded popular components
   const popularComponents = [
@@ -458,12 +460,15 @@ export function Navbar() {
 
           {/* GitHub and Theme Toggle buttons */}
           <a
-            href="https://github.com/w3-kit"
+            href="https://github.com/w3-kit/ui"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center justify-center rounded-md text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white"
+            className="inline-flex items-center gap-1.5 justify-center rounded-md text-sm font-medium text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors"
           >
             <Github className="h-5 w-5" />
+            {stars !== null && (
+              <span className="text-xs font-medium">{stars}</span>
+            )}
             <span className="sr-only">GitHub</span>
           </a>
           <button

--- a/src/hooks/useGitHubStars.ts
+++ b/src/hooks/useGitHubStars.ts
@@ -1,0 +1,75 @@
+import { useState, useEffect } from "react";
+
+interface GitHubRepoInfo {
+  stargazers_count: number;
+}
+
+interface CachedStars {
+  count: number;
+  timestamp: number;
+}
+
+const CACHE_KEY = "github_stars_w3-kit_ui";
+const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
+
+export function useGitHubStars(repo: string) {
+  const [stars, setStars] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchStars = async () => {
+      try {
+        // Check cache first
+        const cached = localStorage.getItem(CACHE_KEY);
+        if (cached) {
+          const cachedData: CachedStars = JSON.parse(cached);
+          const now = Date.now();
+          if (now - cachedData.timestamp < CACHE_DURATION) {
+            setStars(cachedData.count);
+            setIsLoading(false);
+            return;
+          }
+        }
+
+        // Extract owner and repo name from the full repo path
+        const repoPath = repo.replace("https://github.com/", "");
+        const response = await fetch(
+          `https://api.github.com/repos/${repoPath}`,
+          {
+            headers: {
+              Accept: "application/vnd.github.v3+json",
+            },
+          }
+        );
+
+        if (response.ok) {
+          const data: GitHubRepoInfo = await response.json();
+          const starCount = data.stargazers_count;
+          setStars(starCount);
+          
+          // Cache the result
+          const cacheData: CachedStars = {
+            count: starCount,
+            timestamp: Date.now(),
+          };
+          localStorage.setItem(CACHE_KEY, JSON.stringify(cacheData));
+        }
+      } catch (error) {
+        console.error("Failed to fetch GitHub stars:", error);
+        // Try to use cached value even if expired
+        const cached = localStorage.getItem(CACHE_KEY);
+        if (cached) {
+          const cachedData: CachedStars = JSON.parse(cached);
+          setStars(cachedData.count);
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchStars();
+  }, [repo]);
+
+  return { stars, isLoading };
+}
+


### PR DESCRIPTION
… hook

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `useGitHubStars` hook and updates the Navbar to show the `w3-kit/ui` repository star count next to the GitHub icon.
> 
> - **Navbar (`src/components/navbar.tsx`)**
>   - Show GitHub star count next to the GitHub icon using `useGitHubStars("https://github.com/w3-kit/ui")`.
>   - Update GitHub link target to `https://github.com/w3-kit/ui` and tweak button styling (add gap/transition).
> - **Hook (`src/hooks/useGitHubStars.ts`)**
>   - New hook to fetch repo `stargazers_count` from GitHub API with 5‑minute `localStorage` caching and basic fallback/error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3a4e9ab805a149ba151d275c4cbc1ed692fe014. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->