### PR TITLE
Update component installation to shadcn format

### DIFF
--- a/src/app/docs/components/asset-portfolio/page.tsx
+++ b/src/app/docs/components/asset-portfolio/page.tsx
@@ -322,7 +322,7 @@ export default function Page() {
                   <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
                     Run the following command to add the Asset Portfolio component to your project:
                   </p>
-                  <CodeBlock code="npx w3-kit@latest add asset-portfolio" id="cli" />
+                  <CodeBlock code="npx shadcn@latest add https://w3-kit.com/registry/asset-portfolio.json" id="cli" />
                   <p className="text-sm text-gray-600 dark:text-gray-400 mt-4">
                     This will:
                   </p>

--- a/src/app/docs/components/bridge/page.tsx
+++ b/src/app/docs/components/bridge/page.tsx
@@ -159,7 +159,7 @@ export default function Page() {
                     Run the following command to add the Bridge component to
                     your project:
                   </p>
-                  <CodeBlock code="npx w3-kit@latest add bridge" id="cli" />
+                  <CodeBlock code="npx shadcn@latest add https://w3-kit.com/registry/bridge.json" id="cli" />
                   <p className="text-sm text-gray-600 dark:text-gray-400 mt-4">
                     This will:
                   </p>

--- a/src/app/docs/components/limit-order-manager/page.tsx
+++ b/src/app/docs/components/limit-order-manager/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { LimitOrderManager, OrderData } from "./component";
+import { LimitOrderManager, OrderData } from "@/components/w3-kit/limit-order-manager";
 import { Code, Eye } from "lucide-react";
 import { CodeBlock } from "@/components/docs/codeBlock";
 
@@ -181,7 +181,7 @@ export default function Page() {
                   <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
                     Run the following command to add the Limit Order Manager component to your project:
                   </p>
-                  <CodeBlock code="npx w3-kit@latest add limit-order-manager" id="cli" />
+                  <CodeBlock code="npx shadcn@latest add https://w3-kit.com/registry/limit-order-manager.json" id="cli" />
                   <p className="text-sm text-gray-600 dark:text-gray-400 mt-4">
                     This will:
                   </p>

--- a/src/app/docs/components/nft-card/page.tsx
+++ b/src/app/docs/components/nft-card/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { NFTCard } from "./component";
+import { NFTCard } from "@/components/w3-kit/nft-card";
 import { Code, Eye } from "lucide-react";
 import { CodeBlock } from "@/components/docs/codeBlock";
 
@@ -175,7 +175,7 @@ export default function Page() {
                   <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
                     Run the following command to add the NFT Card component to your project:
                   </p>
-                  <CodeBlock code="npx w3-kit@latest add nft-card" id="cli" />
+                  <CodeBlock code="npx shadcn@latest add https://w3-kit.com/registry/nft-card.json" id="cli" />
                   <p className="text-sm text-gray-600 dark:text-gray-400 mt-4">
                     This will:
                   </p>

--- a/src/app/docs/components/token-vesting/page.tsx
+++ b/src/app/docs/components/token-vesting/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState, useCallback } from "react";
-import { TokenVesting } from "./component";
+import { TokenVesting } from "@/components/w3-kit/token-vesting";
 import { Code, Eye } from "lucide-react";
 import { CodeBlock } from "@/components/docs/codeBlock";
 
@@ -225,7 +225,7 @@ export default function Page() {
                   <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
                     Run the following command to add the Token Vesting component to your project:
                   </p>
-                  <CodeBlock code="npx w3-kit@latest add token-vesting" id="cli" />
+                  <CodeBlock code="npx shadcn@latest add https://w3-kit.com/registry/token-vesting.json" id="cli" />
                   <p className="text-sm text-gray-600 dark:text-gray-400 mt-4">
                     This will:
                   </p>

--- a/src/components/w3-kit/limit-order-manager-types.ts
+++ b/src/components/w3-kit/limit-order-manager-types.ts
@@ -1,0 +1,27 @@
+export interface OrderData {
+  id: string;
+  type: "limit" | "stop-loss";
+  token: {
+    symbol: string;
+    logoURI: string;
+    price: number;
+  };
+  amount: string;
+  price: string;
+  status: "active" | "executed" | "cancelled";
+  timestamp: number;
+  expiry?: number;
+}
+
+export interface LimitOrderManagerProps {
+  orders: OrderData[];
+  onOrderCreate?: (order: Omit<OrderData, "id" | "timestamp">) => void;
+  onOrderCancel?: (orderId: string) => void;
+  className?: string;
+}
+
+export interface FormErrors {
+  amount?: string;
+  price?: string;
+  expiry?: string;
+}

--- a/src/components/w3-kit/limit-order-manager-utils.ts
+++ b/src/components/w3-kit/limit-order-manager-utils.ts
@@ -1,0 +1,50 @@
+import { OrderData, FormErrors } from "./limit-order-manager-types";
+
+export function getStatusColor(status: OrderData["status"]): string {
+  switch (status) {
+    case "active":
+      return "text-green-500 dark:text-green-400";
+    case "executed":
+      return "text-blue-500 dark:text-blue-400";
+    case "cancelled":
+      return "text-red-500 dark:text-red-400";
+  }
+}
+
+export function validateOrderForm(
+  amount: string,
+  price: string,
+  expiry: string
+): FormErrors {
+  const errors: FormErrors = {};
+
+  if (!amount || parseFloat(amount) <= 0) {
+    errors.amount = "Amount must be greater than 0";
+  }
+
+  if (!price || parseFloat(price) <= 0) {
+    errors.price = "Price must be greater than 0";
+  }
+
+  if (expiry && (parseInt(expiry) <= 0 || parseInt(expiry) > 30)) {
+    errors.expiry = "Expiry must be between 1 and 30 days";
+  }
+
+  return errors;
+}
+
+export function formatStatus(status: OrderData["status"]): string {
+  return status.charAt(0).toUpperCase() + status.slice(1);
+}
+
+export function calculateExpiry(days: string): number | undefined {
+  if (!days) return undefined;
+  return Date.now() + parseInt(days) * 24 * 60 * 60 * 1000;
+}
+
+export const DEFAULT_TOKEN = {
+  symbol: "ETH",
+  logoURI:
+    "https://raw.githubusercontent.com/Uniswap/assets/master/blockchains/ethereum/assets/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/logo.png",
+  price: 2845.67,
+};

--- a/src/components/w3-kit/limit-order-manager.tsx
+++ b/src/components/w3-kit/limit-order-manager.tsx
@@ -1,0 +1,346 @@
+"use client";
+
+import React, { useState } from "react";
+import { TrendingDown, TrendingUp, Check, Trash2 } from "lucide-react";
+import { OrderData, LimitOrderManagerProps, FormErrors } from "./limit-order-manager-types";
+import {
+  getStatusColor,
+  validateOrderForm,
+  formatStatus,
+  calculateExpiry,
+  DEFAULT_TOKEN,
+} from "./limit-order-manager-utils";
+
+export function LimitOrderManager({
+  orders: initialOrders,
+  onOrderCreate,
+  onOrderCancel,
+  className = "",
+}: LimitOrderManagerProps) {
+  const [orders, setOrders] = useState<OrderData[]>(initialOrders);
+  const [showCreateOrder, setShowCreateOrder] = useState(false);
+  const [orderType, setOrderType] = useState<"limit" | "stop-loss">("limit");
+  const [amount, setAmount] = useState("");
+  const [price, setPrice] = useState("");
+  const [expiry, setExpiry] = useState("");
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [showCancelModal, setShowCancelModal] = useState(false);
+  const [orderToCancel, setOrderToCancel] = useState<string | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
+
+  const handleCreateOrder = async () => {
+    const validationErrors = validateOrderForm(amount, price, expiry);
+    setErrors(validationErrors);
+
+    if (Object.keys(validationErrors).length > 0) return;
+
+    setIsCreating(true);
+    try {
+      const newOrder: OrderData = {
+        id: Date.now().toString(),
+        type: orderType,
+        token: DEFAULT_TOKEN,
+        amount,
+        price,
+        status: "active",
+        timestamp: Date.now(),
+        expiry: calculateExpiry(expiry),
+      };
+
+      setOrders((prev) => [...prev, newOrder]);
+      await onOrderCreate?.({
+        type: orderType,
+        token: newOrder.token,
+        amount,
+        price,
+        status: "active",
+        expiry: newOrder.expiry,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      setShowSuccess(true);
+      setTimeout(() => {
+        setShowSuccess(false);
+        setAmount("");
+        setPrice("");
+        setExpiry("");
+        setErrors({});
+        setShowCreateOrder(false);
+      }, 1500);
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleCancelClick = (orderId: string) => {
+    setOrderToCancel(orderId);
+    setShowCancelModal(true);
+  };
+
+  const handleConfirmCancel = () => {
+    if (orderToCancel) {
+      setOrders((prev) =>
+        prev.map((order) =>
+          order.id === orderToCancel
+            ? { ...order, status: "cancelled" as const }
+            : order
+        )
+      );
+      onOrderCancel?.(orderToCancel);
+      setShowCancelModal(false);
+      setOrderToCancel(null);
+    }
+  };
+
+  const handleDeleteOrder = (orderId: string) => {
+    setOrders((prev) => prev.filter((order) => order.id !== orderId));
+  };
+
+  return (
+    <div
+      className={`bg-white dark:bg-gray-800 rounded-lg shadow-lg p-4 ${className}`}
+    >
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+          Limit Orders
+        </h2>
+        <button
+          onClick={() => setShowCreateOrder(!showCreateOrder)}
+          className="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors"
+        >
+          Create Order
+        </button>
+      </div>
+
+      {/* Create Order Form with Transitions */}
+      <div
+        className={`transition-all duration-300 ease-in-out ${
+          showCreateOrder
+            ? "opacity-100 max-h-[1000px] mb-6"
+            : "opacity-0 max-h-0 overflow-hidden"
+        }`}
+      >
+        <div className="p-4 bg-gray-50 dark:bg-gray-700 rounded-lg">
+          <div className="flex space-x-2 mb-4">
+            <button
+              onClick={() => setOrderType("limit")}
+              className={`px-4 py-2 rounded-lg transition-colors ${
+                orderType === "limit"
+                  ? "bg-blue-500 text-white"
+                  : "bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300"
+              }`}
+            >
+              Limit Order
+            </button>
+            <button
+              onClick={() => setOrderType("stop-loss")}
+              className={`px-4 py-2 rounded-lg transition-colors ${
+                orderType === "stop-loss"
+                  ? "bg-blue-500 text-white"
+                  : "bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300"
+              }`}
+            >
+              Stop Loss
+            </button>
+          </div>
+
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Amount
+              </label>
+              <input
+                type="number"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                className={`w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white ${
+                  errors.amount
+                    ? "border-red-500"
+                    : "border-gray-300 dark:border-gray-600"
+                }`}
+                placeholder="0.0"
+              />
+              {errors.amount && (
+                <p className="mt-1 text-sm text-red-500">{errors.amount}</p>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Price
+              </label>
+              <input
+                type="number"
+                value={price}
+                onChange={(e) => setPrice(e.target.value)}
+                className={`w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white ${
+                  errors.price
+                    ? "border-red-500"
+                    : "border-gray-300 dark:border-gray-600"
+                }`}
+                placeholder="0.0"
+              />
+              {errors.price && (
+                <p className="mt-1 text-sm text-red-500">{errors.price}</p>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Expiry (days)
+              </label>
+              <input
+                type="number"
+                value={expiry}
+                onChange={(e) => setExpiry(e.target.value)}
+                className={`w-full px-3 py-2 border rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white ${
+                  errors.expiry
+                    ? "border-red-500"
+                    : "border-gray-300 dark:border-gray-600"
+                }`}
+                placeholder="Optional"
+              />
+              {errors.expiry && (
+                <p className="mt-1 text-sm text-red-500">{errors.expiry}</p>
+              )}
+            </div>
+
+            <button
+              onClick={handleCreateOrder}
+              disabled={isCreating || showSuccess}
+              className={`w-full px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors flex items-center justify-center relative ${
+                isCreating || showSuccess ? "opacity-75 cursor-not-allowed" : ""
+              }`}
+            >
+              {isCreating ? (
+                <>
+                  <svg
+                    className="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    />
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    />
+                  </svg>
+                  Creating Order...
+                </>
+              ) : showSuccess ? (
+                <>
+                  <Check className="w-5 h-5 mr-2" />
+                  Order Created!
+                </>
+              ) : (
+                "Create Order"
+              )}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        {orders.map((order) => (
+          <div
+            key={order.id}
+            className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-700 rounded-lg group"
+          >
+            <div className="flex items-center space-x-3">
+              <div className="relative">
+                <img
+                  src={order.token.logoURI}
+                  alt={order.token.symbol}
+                  width={32}
+                  height={32}
+                  className="rounded-full"
+                />
+                {order.type === "stop-loss" ? (
+                  <TrendingDown className="absolute -top-1 -right-1 w-4 h-4 text-red-500" />
+                ) : (
+                  <TrendingUp className="absolute -top-1 -right-1 w-4 h-4 text-green-500" />
+                )}
+              </div>
+              <div>
+                <div className="font-medium text-gray-900 dark:text-white">
+                  {order.amount} {order.token.symbol}
+                </div>
+                <div className="text-sm text-gray-500 dark:text-gray-400">
+                  {order.type === "limit" ? "Limit" : "Stop Loss"} @ $
+                  {order.price}
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-center space-x-4">
+              <div className="text-sm">
+                <span className={`font-medium ${getStatusColor(order.status)}`}>
+                  {formatStatus(order.status)}
+                </span>
+              </div>
+              {order.status === "active" ? (
+                <button
+                  onClick={() => handleCancelClick(order.id)}
+                  className="text-red-500 hover:text-red-600 transition-colors"
+                >
+                  Cancel
+                </button>
+              ) : (
+                <button
+                  onClick={() => handleDeleteOrder(order.id)}
+                  className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-red-500"
+                  title="Delete order"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Cancel Confirmation Modal */}
+      {showCancelModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md w-full mx-4">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+              Confirm Cancellation
+            </h3>
+            <p className="text-gray-600 dark:text-gray-400 mb-6">
+              Are you sure you want to cancel this order? This action cannot be
+              undone.
+            </p>
+            <div className="flex justify-end space-x-4">
+              <button
+                onClick={() => setShowCancelModal(false)}
+                className="px-4 py-2 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100"
+              >
+                No, Keep Order
+              </button>
+              <button
+                onClick={handleConfirmCancel}
+                className="px-4 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors"
+              >
+                Yes, Cancel Order
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export { OrderData, LimitOrderManagerProps } from "./limit-order-manager-types";
+export default LimitOrderManager;

--- a/src/components/w3-kit/token-vesting-types.ts
+++ b/src/components/w3-kit/token-vesting-types.ts
@@ -1,0 +1,17 @@
+export interface VestingSchedule {
+  id: string;
+  tokenSymbol: string;
+  totalAmount: string;
+  vestedAmount: string;
+  startDate: number;
+  endDate: number;
+  cliffDate: number;
+  lastClaimDate: number | null;
+  beneficiary: string;
+  status: 'active' | 'completed' | 'pending';
+}
+
+export interface TokenVestingProps {
+  vestingSchedules: VestingSchedule[];
+  onClaimTokens: (scheduleId: string) => Promise<void>;
+}

--- a/src/components/w3-kit/token-vesting-utils.ts
+++ b/src/components/w3-kit/token-vesting-utils.ts
@@ -1,0 +1,43 @@
+import { VestingSchedule } from './token-vesting-types';
+
+export function calculateProgress(schedule: VestingSchedule): number {
+  const now = Date.now();
+  const total = schedule.endDate - schedule.startDate;
+  const current = now - schedule.startDate;
+  return Math.min(Math.max((current / total) * 100, 0), 100);
+}
+
+export function formatDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  });
+}
+
+export function isClaimable(schedule: VestingSchedule): boolean {
+  const now = Date.now();
+  return (
+    schedule.status === 'active' &&
+    now >= schedule.cliffDate &&
+    parseFloat(schedule.vestedAmount) < parseFloat(schedule.totalAmount)
+  );
+}
+
+export const statusConfig = {
+  active: {
+    bg: 'bg-green-100 dark:bg-green-900/30',
+    text: 'text-green-800 dark:text-green-400',
+    label: 'Active'
+  },
+  completed: {
+    bg: 'bg-muted',
+    text: 'text-muted-foreground',
+    label: 'Completed'
+  },
+  pending: {
+    bg: 'bg-yellow-100 dark:bg-yellow-900/30',
+    text: 'text-yellow-800 dark:text-yellow-400',
+    label: 'Pending'
+  }
+};

--- a/src/components/w3-kit/token-vesting.tsx
+++ b/src/components/w3-kit/token-vesting.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import React, { useState, useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { VestingSchedule, TokenVestingProps } from './token-vesting-types';
+import { calculateProgress, formatDate, isClaimable, statusConfig } from './token-vesting-utils';
+
+const StatusBadge: React.FC<{ status: VestingSchedule['status'] }> = ({ status }) => {
+  const config = statusConfig[status];
+  return (
+    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${config.bg} ${config.text}`}>
+      {config.label}
+    </span>
+  );
+};
+
+export function TokenVesting({ vestingSchedules, onClaimTokens }: TokenVestingProps) {
+  const [claimingId, setClaimingId] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const handleClaim = async (e: React.MouseEvent, scheduleId: string) => {
+    e.stopPropagation();
+    try {
+      setClaimingId(scheduleId);
+      await onClaimTokens(scheduleId);
+    } finally {
+      setClaimingId(null);
+    }
+  };
+
+  const sortedSchedules = useMemo(() => {
+    return [...vestingSchedules].sort((a, b) => {
+      const statusOrder = { active: 0, pending: 1, completed: 2 };
+      return statusOrder[a.status] - statusOrder[b.status];
+    });
+  }, [vestingSchedules]);
+
+  return (
+    <div className="space-y-4">
+      {sortedSchedules.map((schedule, index) => (
+        <Card
+          key={schedule.id}
+          className="group cursor-pointer transition-all duration-200 ease-out
+            hover:-translate-y-0.5 hover:shadow-md active:translate-y-0"
+          onClick={() => setExpandedId(expandedId === schedule.id ? null : schedule.id)}
+          style={{ animationDelay: `${index * 100}ms` }}
+        >
+          <CardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-3">
+                <h3 className="text-lg font-semibold text-foreground">
+                  {schedule.tokenSymbol} Vesting
+                </h3>
+                <StatusBadge status={schedule.status} />
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                className={`rounded-full transition-transform duration-200
+                  ${expandedId === schedule.id ? 'rotate-180' : ''}`}
+              >
+                <svg className="w-5 h-5 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                </svg>
+              </Button>
+            </div>
+          </CardHeader>
+
+          <CardContent>
+            <div>
+              <div className="flex justify-between text-sm mb-2">
+                <span className="text-muted-foreground">Progress</span>
+                <span className="text-foreground font-medium">
+                  {calculateProgress(schedule).toFixed(1)}%
+                </span>
+              </div>
+              <div className="relative w-full bg-muted rounded-full h-2 overflow-hidden">
+                <div
+                  className="absolute inset-0 bg-gradient-to-r from-transparent via-white/10 to-transparent
+                    animate-shimmer"
+                  style={{ '--tw-translate-x': '-100%' } as React.CSSProperties}
+                />
+                <div
+                  className="bg-blue-500 dark:bg-blue-400 h-full rounded-full transition-all duration-700 ease-out"
+                  style={{ width: `${calculateProgress(schedule)}%` }}
+                />
+              </div>
+            </div>
+
+            <div
+              className={`mt-4 transition-all duration-300 ease-out overflow-hidden
+                ${expandedId === schedule.id ? 'max-h-[500px] opacity-100' : 'max-h-0 opacity-0'}`}
+            >
+              <p className="text-sm text-muted-foreground mb-4">
+                {formatDate(schedule.startDate)} - {formatDate(schedule.endDate)}
+              </p>
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+                <div className="bg-muted p-4 rounded-lg transition-colors duration-200 hover:bg-muted/80">
+                  <span className="text-muted-foreground text-sm">Total Amount</span>
+                  <p className="font-medium text-foreground mt-1">
+                    {schedule.totalAmount} {schedule.tokenSymbol}
+                  </p>
+                </div>
+                <div className="bg-muted p-4 rounded-lg transition-colors duration-200 hover:bg-muted/80">
+                  <span className="text-muted-foreground text-sm">Vested Amount</span>
+                  <p className="font-medium text-foreground mt-1">
+                    {schedule.vestedAmount} {schedule.tokenSymbol}
+                  </p>
+                </div>
+                <div className="bg-muted p-4 rounded-lg transition-colors duration-200 hover:bg-muted/80">
+                  <span className="text-muted-foreground text-sm">Cliff Date</span>
+                  <p className="font-medium text-foreground mt-1">
+                    {formatDate(schedule.cliffDate)}
+                  </p>
+                </div>
+                <div className="bg-muted p-4 rounded-lg transition-colors duration-200 hover:bg-muted/80">
+                  <span className="text-muted-foreground text-sm">Last Claimed</span>
+                  <p className="font-medium text-foreground mt-1">
+                    {schedule.lastClaimDate ? formatDate(schedule.lastClaimDate) : 'Never'}
+                  </p>
+                </div>
+              </div>
+
+              {isClaimable(schedule) && (
+                <Button
+                  onClick={(e) => handleClaim(e, schedule.id)}
+                  disabled={claimingId === schedule.id}
+                  className="w-full mt-4 transition-all duration-200 ease-out active:translate-y-0.5"
+                >
+                  {claimingId === schedule.id ? (
+                    <>
+                      <svg
+                        className="animate-spin -ml-1 mr-2 h-4 w-4 text-white"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                      >
+                        <circle
+                          className="opacity-25"
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke="currentColor"
+                          strokeWidth="4"
+                        />
+                        <path
+                          className="opacity-75"
+                          fill="currentColor"
+                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                        />
+                      </svg>
+                      Claiming Tokens...
+                    </>
+                  ) : (
+                    <>
+                      <svg
+                        className="mr-2 h-4 w-4"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                        />
+                      </svg>
+                      Claim Available Tokens
+                    </>
+                  )}
+                </Button>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+export { VestingSchedule, TokenVestingProps } from './token-vesting-types';
+export default TokenVesting;


### PR DESCRIPTION
## Summary
- Update CLI installation command for asset-portfolio, bridge, limit-order-manager, nft-card, and token-vesting
- Migrate from `npx w3-kit@latest add` to `npx shadcn@latest add https://w3-kit.com/registry/...`
- Add limit-order-manager component files to components/w3-kit/
- Add token-vesting component files to components/w3-kit/
- Update imports in limit-order-manager, nft-card, and token-vesting pages to use @/components/w3-kit/

## Test plan
- [ ] Verify asset-portfolio page displays correctly with updated CLI command
- [ ] Verify bridge page displays correctly with updated CLI command
- [ ] Verify limit-order-manager page loads with new component import
- [ ] Verify nft-card page loads with new component import
- [ ] Verify token-vesting page loads with new component import
- [ ] Test that all components render their previews correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)