### PR TITLE
fix: run build before typecheck to generate TanStack route tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci --legacy-peer-deps
+      - run: npm run build
       - run: npm run typecheck
       - run: npm run lint
       - run: npm run format:check
-      - run: npm run build

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true

--- a/src/pages/design-system/ui/design-system-page.tsx
+++ b/src/pages/design-system/ui/design-system-page.tsx
@@ -43,18 +43,73 @@ const grayScale = [
 ];
 
 const headingTypes = [
-  { example: "Heading 48", className: "text-heading-48", size: "48px", weight: 600, usage: "Hero sections and landing pages." },
-  { example: "Heading 32", className: "text-heading-32", size: "32px", weight: 600, usage: "Page titles and major sections." },
-  { example: "Heading 24", className: "text-heading-24", size: "24px", weight: 600, usage: "Section headings within pages." },
-  { example: "Heading 20", className: "text-heading-20", size: "20px", weight: 500, usage: "Sub-section headings." },
+  {
+    example: "Heading 48",
+    className: "text-heading-48",
+    size: "48px",
+    weight: 600,
+    usage: "Hero sections and landing pages.",
+  },
+  {
+    example: "Heading 32",
+    className: "text-heading-32",
+    size: "32px",
+    weight: 600,
+    usage: "Page titles and major sections.",
+  },
+  {
+    example: "Heading 24",
+    className: "text-heading-24",
+    size: "24px",
+    weight: 600,
+    usage: "Section headings within pages.",
+  },
+  {
+    example: "Heading 20",
+    className: "text-heading-20",
+    size: "20px",
+    weight: 500,
+    usage: "Sub-section headings.",
+  },
 ];
 
 const copyTypes = [
-  { example: "Copy 16 with Strong", className: "text-copy-16", size: "16px", weight: 400, usage: "Default body text for content." },
-  { example: "Copy 14 with Strong", className: "text-copy-14", size: "14px", weight: 400, usage: "Most commonly used text style." },
-  { example: "Copy 13", className: "text-copy-13", size: "13px", weight: 400, usage: "Secondary text and descriptions." },
-  { example: "Copy 13 Mono", className: "text-copy-13-mono", size: "13px", weight: 400, usage: "Used for inline code mentions.", mono: true },
-  { example: "Copy 12", className: "text-copy-12", size: "12px", weight: 400, usage: "Captions and metadata." },
+  {
+    example: "Copy 16 with Strong",
+    className: "text-copy-16",
+    size: "16px",
+    weight: 400,
+    usage: "Default body text for content.",
+  },
+  {
+    example: "Copy 14 with Strong",
+    className: "text-copy-14",
+    size: "14px",
+    weight: 400,
+    usage: "Most commonly used text style.",
+  },
+  {
+    example: "Copy 13",
+    className: "text-copy-13",
+    size: "13px",
+    weight: 400,
+    usage: "Secondary text and descriptions.",
+  },
+  {
+    example: "Copy 13 Mono",
+    className: "text-copy-13-mono",
+    size: "13px",
+    weight: 400,
+    usage: "Used for inline code mentions.",
+    mono: true,
+  },
+  {
+    example: "Copy 12",
+    className: "text-copy-12",
+    size: "12px",
+    weight: 400,
+    usage: "Captions and metadata.",
+  },
 ];
 
 const spacingValues = [4, 8, 16, 24, 32, 48, 64];
@@ -70,7 +125,14 @@ const inputBaseStyle: React.CSSProperties = {
 
 export function DesignSystemPage() {
   return (
-    <div style={{ minHeight: "100vh", display: "flex", flexDirection: "column", background: "var(--w3-gray-100)" }}>
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        background: "var(--w3-gray-100)",
+      }}
+    >
       <SiteHeader currentSection="design" />
 
       <div style={{ display: "flex", flex: 1 }}>
@@ -87,7 +149,9 @@ export function DesignSystemPage() {
             overflowY: "auto",
           }}
         >
-          <div style={{ fontSize: 15, fontWeight: 600, color: "var(--w3-gray-900)", marginBottom: 24 }}>
+          <div
+            style={{ fontSize: 15, fontWeight: 600, color: "var(--w3-gray-900)", marginBottom: 24 }}
+          >
             w3-kit Design System
           </div>
 
@@ -137,21 +201,30 @@ export function DesignSystemPage() {
 
         {/* Main content */}
         <div style={{ flex: 1, padding: "48px 64px", maxWidth: 900 }}>
-
           {/* Introduction */}
           <section id="intro" style={{ marginBottom: 80 }}>
             <h1 style={{ marginBottom: 16 }}>Design System</h1>
-            <p style={{ fontSize: 16, color: "var(--w3-gray-700)", lineHeight: 1.6, maxWidth: 600 }}>
-              The visual language for w3-kit. Monochrome foundations with Solidity purple as a structural accent.
-              Built on Geist Sans, a 10-step gray scale, and GSAP-driven motion.
+            <p
+              style={{ fontSize: 16, color: "var(--w3-gray-700)", lineHeight: 1.6, maxWidth: 600 }}
+            >
+              The visual language for w3-kit. Monochrome foundations with Solidity purple as a
+              structural accent. Built on Geist Sans, a 10-step gray scale, and GSAP-driven motion.
             </p>
           </section>
 
           {/* Colors */}
           <section id="colors" style={{ marginBottom: 80 }}>
             <h2 style={{ marginBottom: 8 }}>Colors</h2>
-            <p style={{ fontSize: 14, color: "var(--w3-gray-700)", marginBottom: 32, lineHeight: 1.6 }}>
-              10-step semantic gray scale. Values swap automatically between light and dark themes via CSS custom properties.
+            <p
+              style={{
+                fontSize: 14,
+                color: "var(--w3-gray-700)",
+                marginBottom: 32,
+                lineHeight: 1.6,
+              }}
+            >
+              10-step semantic gray scale. Values swap automatically between light and dark themes
+              via CSS custom properties.
             </p>
 
             {/* Gray scale table */}
@@ -214,7 +287,9 @@ export function DesignSystemPage() {
                     marginBottom: 8,
                   }}
                 />
-                <div style={{ fontSize: 13, fontWeight: 500, color: "var(--w3-gray-900)" }}>Accent</div>
+                <div style={{ fontSize: 13, fontWeight: 500, color: "var(--w3-gray-900)" }}>
+                  Accent
+                </div>
                 <code style={{ fontSize: 12, color: "var(--w3-gray-600)" }}>#5554D9</code>
               </div>
               <div>
@@ -228,7 +303,9 @@ export function DesignSystemPage() {
                     marginBottom: 8,
                   }}
                 />
-                <div style={{ fontSize: 13, fontWeight: 500, color: "var(--w3-gray-900)" }}>Accent Subtle</div>
+                <div style={{ fontSize: 13, fontWeight: 500, color: "var(--w3-gray-900)" }}>
+                  Accent Subtle
+                </div>
                 <code style={{ fontSize: 12, color: "var(--w3-gray-600)" }}>Backgrounds</code>
               </div>
             </div>
@@ -237,8 +314,16 @@ export function DesignSystemPage() {
           {/* Typography */}
           <section id="typography" style={{ marginBottom: 80 }}>
             <h2 style={{ marginBottom: 8 }}>Typography</h2>
-            <p style={{ fontSize: 14, color: "var(--w3-gray-700)", marginBottom: 32, lineHeight: 1.6 }}>
-              Geist Sans for UI text, Geist Mono for code. Tight letter-spacing on headings, comfortable line-height on body copy.
+            <p
+              style={{
+                fontSize: 14,
+                color: "var(--w3-gray-700)",
+                marginBottom: 32,
+                lineHeight: 1.6,
+              }}
+            >
+              Geist Sans for UI text, Geist Mono for code. Tight letter-spacing on headings,
+              comfortable line-height on body copy.
             </p>
 
             {/* Heading */}
@@ -275,11 +360,21 @@ export function DesignSystemPage() {
                   borderBottom: "1px solid var(--w3-gray-300)",
                 }}
               >
-                <span style={{ fontSize: t.size, fontWeight: t.weight, color: "var(--w3-gray-900)", letterSpacing: "-0.02em", lineHeight: 1.1 }}>
+                <span
+                  style={{
+                    fontSize: t.size,
+                    fontWeight: t.weight,
+                    color: "var(--w3-gray-900)",
+                    letterSpacing: "-0.02em",
+                    lineHeight: 1.1,
+                  }}
+                >
                   {t.example}
                 </span>
                 <code style={{ fontSize: 13, color: "var(--w3-gray-700)" }}>{t.className}</code>
-                <span style={{ fontSize: 14, color: "var(--w3-gray-700)", lineHeight: 1.5 }}>{t.usage}</span>
+                <span style={{ fontSize: 14, color: "var(--w3-gray-700)", lineHeight: 1.5 }}>
+                  {t.usage}
+                </span>
               </div>
             ))}
 
@@ -334,13 +429,30 @@ export function DesignSystemPage() {
                   )}
                 </span>
                 <code style={{ fontSize: 13, color: "var(--w3-gray-700)" }}>{t.className}</code>
-                <span style={{ fontSize: 14, color: "var(--w3-gray-700)", lineHeight: 1.5 }}>{t.usage}</span>
+                <span style={{ fontSize: 14, color: "var(--w3-gray-700)", lineHeight: 1.5 }}>
+                  {t.usage}
+                </span>
               </div>
             ))}
 
             {/* Mono specimen */}
-            <div style={{ marginTop: 32, padding: 20, background: "var(--w3-gray-200)", borderRadius: 6 }}>
-              <div style={{ fontSize: 12, color: "var(--w3-gray-600)", marginBottom: 8, textTransform: "uppercase", letterSpacing: "0.05em" }}>
+            <div
+              style={{
+                marginTop: 32,
+                padding: 20,
+                background: "var(--w3-gray-200)",
+                borderRadius: 6,
+              }}
+            >
+              <div
+                style={{
+                  fontSize: 12,
+                  color: "var(--w3-gray-600)",
+                  marginBottom: 8,
+                  textTransform: "uppercase",
+                  letterSpacing: "0.05em",
+                }}
+              >
                 Geist Mono
               </div>
               <code style={{ fontSize: 14, color: "var(--w3-gray-900)" }}>
@@ -352,7 +464,14 @@ export function DesignSystemPage() {
           {/* Spacing */}
           <section id="spacing" style={{ marginBottom: 80 }}>
             <h2 style={{ marginBottom: 8 }}>Spacing</h2>
-            <p style={{ fontSize: 14, color: "var(--w3-gray-700)", marginBottom: 32, lineHeight: 1.6 }}>
+            <p
+              style={{
+                fontSize: 14,
+                color: "var(--w3-gray-700)",
+                marginBottom: 32,
+                lineHeight: 1.6,
+              }}
+            >
               4px base unit. All spacing is a multiple of 4 or 8.
             </p>
 
@@ -387,7 +506,14 @@ export function DesignSystemPage() {
           {/* Buttons */}
           <section id="buttons" style={{ marginBottom: 80 }}>
             <h2 style={{ marginBottom: 8 }}>Buttons</h2>
-            <p style={{ fontSize: 14, color: "var(--w3-gray-700)", marginBottom: 32, lineHeight: 1.6 }}>
+            <p
+              style={{
+                fontSize: 14,
+                color: "var(--w3-gray-700)",
+                marginBottom: 32,
+                lineHeight: 1.6,
+              }}
+            >
               Button variants following the monochrome design system.
             </p>
 
@@ -421,7 +547,14 @@ export function DesignSystemPage() {
           {/* Badges */}
           <section id="badges" style={{ marginBottom: 80 }}>
             <h2 style={{ marginBottom: 8 }}>Badges</h2>
-            <p style={{ fontSize: 14, color: "var(--w3-gray-700)", marginBottom: 32, lineHeight: 1.6 }}>
+            <p
+              style={{
+                fontSize: 14,
+                color: "var(--w3-gray-700)",
+                marginBottom: 32,
+                lineHeight: 1.6,
+              }}
+            >
               Status indicators and labels.
             </p>
 
@@ -451,19 +584,35 @@ export function DesignSystemPage() {
           {/* Inputs */}
           <section id="inputs" style={{ marginBottom: 80 }}>
             <h2 style={{ marginBottom: 8 }}>Inputs</h2>
-            <p style={{ fontSize: 14, color: "var(--w3-gray-700)", marginBottom: 32, lineHeight: 1.6 }}>
+            <p
+              style={{
+                fontSize: 14,
+                color: "var(--w3-gray-700)",
+                marginBottom: 32,
+                lineHeight: 1.6,
+              }}
+            >
               Form input states.
             </p>
 
             <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
               <input
                 placeholder="Default input"
-                style={{ ...inputBaseStyle, background: "var(--w3-gray-100)", color: "var(--w3-gray-900)" }}
+                style={{
+                  ...inputBaseStyle,
+                  background: "var(--w3-gray-100)",
+                  color: "var(--w3-gray-900)",
+                }}
               />
               <input
                 placeholder="Disabled"
                 disabled
-                style={{ ...inputBaseStyle, background: "var(--w3-gray-200)", color: "var(--w3-gray-500)", cursor: "not-allowed" }}
+                style={{
+                  ...inputBaseStyle,
+                  background: "var(--w3-gray-200)",
+                  color: "var(--w3-gray-500)",
+                  cursor: "not-allowed",
+                }}
               />
             </div>
           </section>
@@ -471,7 +620,14 @@ export function DesignSystemPage() {
           {/* Cards */}
           <section id="cards" style={{ marginBottom: 80 }}>
             <h2 style={{ marginBottom: 8 }}>Cards</h2>
-            <p style={{ fontSize: 14, color: "var(--w3-gray-700)", marginBottom: 32, lineHeight: 1.6 }}>
+            <p
+              style={{
+                fontSize: 14,
+                color: "var(--w3-gray-700)",
+                marginBottom: 32,
+                lineHeight: 1.6,
+              }}
+            >
               Container components with surface background.
             </p>
 
@@ -494,8 +650,16 @@ export function DesignSystemPage() {
           {/* Animations */}
           <section id="animations" style={{ marginBottom: 80 }}>
             <h2 style={{ marginBottom: 8 }}>Animations</h2>
-            <p style={{ fontSize: 14, color: "var(--w3-gray-700)", marginBottom: 32, lineHeight: 1.6 }}>
-              GSAP-driven abstract structural SVG animations. Each subdomain has a unique animation that hints at its content.
+            <p
+              style={{
+                fontSize: 14,
+                color: "var(--w3-gray-700)",
+                marginBottom: 32,
+                lineHeight: 1.6,
+              }}
+            >
+              GSAP-driven abstract structural SVG animations. Each subdomain has a unique animation
+              that hints at its content.
             </p>
 
             <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 16 }}>
@@ -514,7 +678,14 @@ export function DesignSystemPage() {
                     overflow: "hidden",
                   }}
                 >
-                  <div style={{ height: 200, display: "flex", alignItems: "center", justifyContent: "center" }}>
+                  <div
+                    style={{
+                      height: 200,
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+                    }}
+                  >
                     {anim.component}
                   </div>
                   <div

--- a/src/pages/under-construction/ui/docs-animation.tsx
+++ b/src/pages/under-construction/ui/docs-animation.tsx
@@ -24,13 +24,13 @@ export function DocsAnimation() {
     tl.fromTo(
       ".sidebar",
       { scaleY: 0, transformOrigin: "top" },
-      { scaleY: 1, duration: 1, ease: "power2.out" }
+      { scaleY: 1, duration: 1, ease: "power2.out" },
     );
     tl.fromTo(
       ".text-line",
       { x: -300, opacity: 0 },
       { x: 0, opacity: 1, duration: 0.5, stagger: 0.04, ease: "power2.out" },
-      "-=0.6"
+      "-=0.6",
     );
   });
 
@@ -43,7 +43,11 @@ export function DocsAnimation() {
         <rect
           key={i}
           className="text-line"
-          x="80" y={line.y} width={line.w} height={line.h} rx="1"
+          x="80"
+          y={line.y}
+          width={line.w}
+          height={line.h}
+          rx="1"
           fill={line.isHeading ? a : g4}
           opacity={line.isHeading ? 0.8 : 0.4}
         />

--- a/src/pages/under-construction/ui/landing-animation.tsx
+++ b/src/pages/under-construction/ui/landing-animation.tsx
@@ -5,19 +5,19 @@ export function LandingAnimation() {
     tl.fromTo(
       ".h-line",
       { x: -500, opacity: 0 },
-      { x: 0, opacity: 1, duration: 0.8, stagger: 0.05, ease: "power2.out" }
+      { x: 0, opacity: 1, duration: 0.8, stagger: 0.05, ease: "power2.out" },
     );
     tl.fromTo(
       ".v-line",
       { y: -400, opacity: 0 },
       { y: 0, opacity: 1, duration: 0.8, stagger: 0.05, ease: "power2.out" },
-      "-=0.4"
+      "-=0.4",
     );
     tl.fromTo(
       ".rect",
       { scale: 0, transformOrigin: "center" },
       { scale: 1, duration: 0.6, stagger: 0.08, ease: "power3.out" },
-      "-=0.3"
+      "-=0.3",
     );
   });
 
@@ -26,21 +26,87 @@ export function LandingAnimation() {
   return (
     <svg ref={svgRef} viewBox={SVG_VIEWBOX} style={SVG_STYLE}>
       {[50, 100, 200, 250].map((y, i) => (
-        <line key={`h${i}`} className="h-line" x1="20" y1={y} x2="380" y2={y}
-          stroke={g4} strokeWidth="0.5" />
+        <line
+          key={`h${i}`}
+          className="h-line"
+          x1="20"
+          y1={y}
+          x2="380"
+          y2={y}
+          stroke={g4}
+          strokeWidth="0.5"
+        />
       ))}
       <line className="h-line" x1="20" y1="150" x2="380" y2="150" stroke={a} strokeWidth="1" />
       {[80, 240, 320].map((x, i) => (
-        <line key={`v${i}`} className="v-line" x1={x} y1="20" x2={x} y2="280"
-          stroke={g4} strokeWidth="0.5" />
+        <line
+          key={`v${i}`}
+          className="v-line"
+          x1={x}
+          y1="20"
+          x2={x}
+          y2="280"
+          stroke={g4}
+          strokeWidth="0.5"
+        />
       ))}
       <line className="v-line" x1="160" y1="20" x2="160" y2="280" stroke={g4} strokeWidth="0.5" />
       <line className="v-line" x1="200" y1="20" x2="200" y2="280" stroke={a} strokeWidth="1" />
-      <rect className="rect" x="72" y="92" width="30" height="20" rx="1" fill="none" stroke={g3} strokeWidth="0.5" />
-      <rect className="rect" x="152" y="142" width="40" height="25" rx="1" fill="none" stroke={a} strokeWidth="0.5" />
-      <rect className="rect" x="232" y="192" width="35" height="20" rx="1" fill="none" stroke={g3} strokeWidth="0.5" />
-      <rect className="rect" x="312" y="92" width="25" height="30" rx="1" fill="none" stroke={g3} strokeWidth="0.5" />
-      <rect className="rect" x="72" y="192" width="40" height="25" rx="1" fill="none" stroke={g3} strokeWidth="0.5" />
+      <rect
+        className="rect"
+        x="72"
+        y="92"
+        width="30"
+        height="20"
+        rx="1"
+        fill="none"
+        stroke={g3}
+        strokeWidth="0.5"
+      />
+      <rect
+        className="rect"
+        x="152"
+        y="142"
+        width="40"
+        height="25"
+        rx="1"
+        fill="none"
+        stroke={a}
+        strokeWidth="0.5"
+      />
+      <rect
+        className="rect"
+        x="232"
+        y="192"
+        width="35"
+        height="20"
+        rx="1"
+        fill="none"
+        stroke={g3}
+        strokeWidth="0.5"
+      />
+      <rect
+        className="rect"
+        x="312"
+        y="92"
+        width="25"
+        height="30"
+        rx="1"
+        fill="none"
+        stroke={g3}
+        strokeWidth="0.5"
+      />
+      <rect
+        className="rect"
+        x="72"
+        y="192"
+        width="40"
+        height="25"
+        rx="1"
+        fill="none"
+        stroke={g3}
+        strokeWidth="0.5"
+      />
     </svg>
   );
 }

--- a/src/pages/under-construction/ui/registry-animation.tsx
+++ b/src/pages/under-construction/ui/registry-animation.tsx
@@ -8,25 +8,25 @@ export function RegistryAnimation() {
     tl.fromTo(
       ".header-line",
       { scaleX: 0, transformOrigin: "left" },
-      { scaleX: 1, duration: 0.6, stagger: 0.05, ease: "power2.out" }
+      { scaleX: 1, duration: 0.6, stagger: 0.05, ease: "power2.out" },
     );
     tl.fromTo(
       ".grid-h",
       { x: -400, opacity: 0 },
       { x: 0, opacity: 1, duration: 0.6, stagger: 0.04, ease: "power2.out" },
-      "-=0.3"
+      "-=0.3",
     );
     tl.fromTo(
       ".grid-v",
       { y: -300, opacity: 0 },
       { y: 0, opacity: 1, duration: 0.6, stagger: 0.05, ease: "power2.out" },
-      "-=0.4"
+      "-=0.4",
     );
     tl.fromTo(
       ".data-dot",
       { scale: 0, transformOrigin: "center" },
       { scale: 1, duration: 0.3, stagger: 0.02, ease: "power3.out" },
-      "-=0.2"
+      "-=0.2",
     );
   });
 
@@ -36,18 +36,53 @@ export function RegistryAnimation() {
     <svg ref={svgRef} viewBox={SVG_VIEWBOX} style={SVG_STYLE}>
       <line className="header-line" x1="40" y1="40" x2="370" y2="40" stroke={a} strokeWidth="1" />
       {cols.map((x, i) => (
-        <rect key={`hdr${i}`} className="header-line" x={x - 20} y="25" width={40} height={4} rx="1" fill={a} opacity="0.6" />
+        <rect
+          key={`hdr${i}`}
+          className="header-line"
+          x={x - 20}
+          y="25"
+          width={40}
+          height={4}
+          rx="1"
+          fill={a}
+          opacity="0.6"
+        />
       ))}
       {rows.map((y, i) => (
-        <line key={`gh${i}`} className="grid-h" x1="40" y1={y} x2="370" y2={y} stroke={g4} strokeWidth="0.5" />
+        <line
+          key={`gh${i}`}
+          className="grid-h"
+          x1="40"
+          y1={y}
+          x2="370"
+          y2={y}
+          stroke={g4}
+          strokeWidth="0.5"
+        />
       ))}
       {cols.map((x, i) => (
-        <line key={`gv${i}`} className="grid-v" x1={x} y1="40" x2={x} y2="280" stroke={g4} strokeWidth="0.5" />
+        <line
+          key={`gv${i}`}
+          className="grid-v"
+          x1={x}
+          y1="40"
+          x2={x}
+          y2="280"
+          stroke={g4}
+          strokeWidth="0.5"
+        />
       ))}
       {cols.map((x) =>
         rows.map((y) => (
-          <circle key={`dot-${x}-${y}`} className="data-dot" cx={x} cy={y} r="2" fill={y === 60 ? a : g3} />
-        ))
+          <circle
+            key={`dot-${x}-${y}`}
+            className="data-dot"
+            cx={x}
+            cy={y}
+            r="2"
+            fill={y === 60 ? a : g3}
+          />
+        )),
       )}
     </svg>
   );

--- a/src/pages/under-construction/ui/ui-animation.tsx
+++ b/src/pages/under-construction/ui/ui-animation.tsx
@@ -5,13 +5,13 @@ export function UiAnimation() {
     tl.fromTo(
       ".comp",
       { scale: 0, transformOrigin: "center", opacity: 0 },
-      { scale: 1, opacity: 1, duration: 0.6, stagger: 0.08, ease: "power3.out" }
+      { scale: 1, opacity: 1, duration: 0.6, stagger: 0.08, ease: "power3.out" },
     );
     tl.fromTo(
       ".inner-line",
       { scaleX: 0, transformOrigin: "left" },
       { scaleX: 1, duration: 0.4, stagger: 0.05, ease: "power2.out" },
-      "-=0.3"
+      "-=0.3",
     );
   });
 
@@ -19,26 +19,154 @@ export function UiAnimation() {
 
   return (
     <svg ref={svgRef} viewBox={SVG_VIEWBOX} style={SVG_STYLE}>
-      <rect className="comp" x="30" y="30" width="100" height="36" rx="4" fill="none" stroke={g3} strokeWidth="0.5" />
+      <rect
+        className="comp"
+        x="30"
+        y="30"
+        width="100"
+        height="36"
+        rx="4"
+        fill="none"
+        stroke={g3}
+        strokeWidth="0.5"
+      />
       <line className="inner-line" x1="50" y1="48" x2="110" y2="48" stroke={g4} strokeWidth="2" />
-      <rect className="comp" x="150" y="30" width="100" height="36" rx="4" fill="none" stroke={a} strokeWidth="1" />
+      <rect
+        className="comp"
+        x="150"
+        y="30"
+        width="100"
+        height="36"
+        rx="4"
+        fill="none"
+        stroke={a}
+        strokeWidth="1"
+      />
       <line className="inner-line" x1="170" y1="48" x2="230" y2="48" stroke={a} strokeWidth="2" />
-      <rect className="comp" x="30" y="90" width="160" height="120" rx="4" fill="none" stroke={g3} strokeWidth="0.5" />
+      <rect
+        className="comp"
+        x="30"
+        y="90"
+        width="160"
+        height="120"
+        rx="4"
+        fill="none"
+        stroke={g3}
+        strokeWidth="0.5"
+      />
       <line className="inner-line" x1="45" y1="115" x2="130" y2="115" stroke={g4} strokeWidth="2" />
       <line className="inner-line" x1="45" y1="135" x2="170" y2="135" stroke={g4} strokeWidth="1" />
       <line className="inner-line" x1="45" y1="150" x2="155" y2="150" stroke={g4} strokeWidth="1" />
       <line className="inner-line" x1="45" y1="165" x2="140" y2="165" stroke={g4} strokeWidth="1" />
-      <rect className="comp" x="45" y="180" width="60" height="20" rx="3" fill="none" stroke={a} strokeWidth="0.5" />
-      <rect className="comp" x="210" y="90" width="160" height="36" rx="4" fill="none" stroke={g3} strokeWidth="0.5" />
-      <line className="inner-line" x1="225" y1="108" x2="290" y2="108" stroke={g4} strokeWidth="1" />
-      <rect className="comp" x="210" y="145" width="60" height="24" rx="12" fill="none" stroke={g3} strokeWidth="0.5" />
-      <rect className="comp" x="280" y="145" width="60" height="24" rx="12" fill="none" stroke={a} strokeWidth="0.5" />
-      <rect className="comp" x="210" y="190" width="48" height="24" rx="12" fill="none" stroke={g3} strokeWidth="0.5" />
+      <rect
+        className="comp"
+        x="45"
+        y="180"
+        width="60"
+        height="20"
+        rx="3"
+        fill="none"
+        stroke={a}
+        strokeWidth="0.5"
+      />
+      <rect
+        className="comp"
+        x="210"
+        y="90"
+        width="160"
+        height="36"
+        rx="4"
+        fill="none"
+        stroke={g3}
+        strokeWidth="0.5"
+      />
+      <line
+        className="inner-line"
+        x1="225"
+        y1="108"
+        x2="290"
+        y2="108"
+        stroke={g4}
+        strokeWidth="1"
+      />
+      <rect
+        className="comp"
+        x="210"
+        y="145"
+        width="60"
+        height="24"
+        rx="12"
+        fill="none"
+        stroke={g3}
+        strokeWidth="0.5"
+      />
+      <rect
+        className="comp"
+        x="280"
+        y="145"
+        width="60"
+        height="24"
+        rx="12"
+        fill="none"
+        stroke={a}
+        strokeWidth="0.5"
+      />
+      <rect
+        className="comp"
+        x="210"
+        y="190"
+        width="48"
+        height="24"
+        rx="12"
+        fill="none"
+        stroke={g3}
+        strokeWidth="0.5"
+      />
       <circle className="comp" cx="246" cy="202" r="8" fill="none" stroke={a} strokeWidth="0.5" />
-      <rect className="comp" x="30" y="240" width="32" height="32" rx="4" fill="none" stroke={g3} strokeWidth="0.5" />
-      <rect className="comp" x="75" y="240" width="32" height="32" rx="4" fill="none" stroke={g3} strokeWidth="0.5" />
-      <rect className="comp" x="120" y="240" width="32" height="32" rx="4" fill="none" stroke={g4} strokeWidth="0.5" />
-      <rect className="comp" x="165" y="240" width="32" height="32" rx="4" fill="none" stroke={a} strokeWidth="0.5" />
+      <rect
+        className="comp"
+        x="30"
+        y="240"
+        width="32"
+        height="32"
+        rx="4"
+        fill="none"
+        stroke={g3}
+        strokeWidth="0.5"
+      />
+      <rect
+        className="comp"
+        x="75"
+        y="240"
+        width="32"
+        height="32"
+        rx="4"
+        fill="none"
+        stroke={g3}
+        strokeWidth="0.5"
+      />
+      <rect
+        className="comp"
+        x="120"
+        y="240"
+        width="32"
+        height="32"
+        rx="4"
+        fill="none"
+        stroke={g4}
+        strokeWidth="0.5"
+      />
+      <rect
+        className="comp"
+        x="165"
+        y="240"
+        width="32"
+        height="32"
+        rx="4"
+        fill="none"
+        stroke={a}
+        strokeWidth="0.5"
+      />
     </svg>
   );
 }

--- a/src/pages/under-construction/ui/under-construction-layout.tsx
+++ b/src/pages/under-construction/ui/under-construction-layout.tsx
@@ -28,9 +28,7 @@ export function UnderConstructionLayout({
             padding: "48px",
           }}
         >
-          <h1 style={{ marginBottom: 12, color: "var(--w3-gray-900)" }}>
-            {title}
-          </h1>
+          <h1 style={{ marginBottom: 12, color: "var(--w3-gray-900)" }}>{title}</h1>
           <p
             style={{
               fontSize: 16,
@@ -45,8 +43,7 @@ export function UnderConstructionLayout({
             style={{
               width: 60,
               height: 1,
-              background:
-                "linear-gradient(90deg, var(--w3-accent), transparent)",
+              background: "linear-gradient(90deg, var(--w3-accent), transparent)",
               marginBottom: 24,
             }}
           />

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,9 +1,4 @@
-import {
-  Outlet,
-  createRootRoute,
-  HeadContent,
-  Scripts,
-} from "@tanstack/react-router";
+import { Outlet, createRootRoute, HeadContent, Scripts } from "@tanstack/react-router";
 import { SpeedInsights } from "@vercel/speed-insights/react";
 import type { ReactNode } from "react";
 import "../shared/styles/tokens.css";

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,4 @@
-import {
-  createStartHandler,
-  defaultStreamHandler,
-} from "@tanstack/react-start/server";
+import { createStartHandler, defaultStreamHandler } from "@tanstack/react-start/server";
 import { createServerEntry } from "@tanstack/react-start/server-entry";
 import { getSubdomain } from "./app/middleware";
 

--- a/src/shared/lib/animation.ts
+++ b/src/shared/lib/animation.ts
@@ -11,9 +11,7 @@ export const STROKE = {
 export const SVG_STYLE = { width: "80%", height: "80%" } as const;
 export const SVG_VIEWBOX = "0 0 400 300";
 
-export function useAnimatedSvg(
-  buildTimeline: (tl: gsap.core.Timeline) => void
-) {
+export function useAnimatedSvg(buildTimeline: (tl: gsap.core.Timeline) => void) {
   const svgRef = useRef<SVGSVGElement>(null);
 
   useGSAP(
@@ -27,7 +25,7 @@ export function useAnimatedSvg(
       });
       return () => mm.revert();
     },
-    { scope: svgRef }
+    { scope: svgRef },
   );
 
   return svgRef;

--- a/src/shared/lib/utils.ts
+++ b/src/shared/lib/utils.ts
@@ -1,6 +1,6 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }

--- a/src/shared/styles/tokens.css
+++ b/src/shared/styles/tokens.css
@@ -47,10 +47,14 @@
   --w3-gray-700: #525252;
   --w3-gray-800: #404040;
   --w3-gray-900: #171717;
-  --w3-accent: #5554D9;
+  --w3-accent: #5554d9;
   --w3-accent-subtle: rgba(85, 84, 217, 0.1);
 
-  font-family: "Geist Sans", system-ui, -apple-system, sans-serif;
+  font-family:
+    "Geist Sans",
+    system-ui,
+    -apple-system,
+    sans-serif;
   color: var(--w3-gray-900);
   background-color: var(--w3-gray-100);
   --background: oklch(1 0 0);
@@ -98,7 +102,7 @@
   --w3-gray-700: #666666;
   --w3-gray-800: #888888;
   --w3-gray-900: #ededed;
-  --w3-accent: #5554D9;
+  --w3-accent: #5554d9;
   --w3-accent-subtle: rgba(85, 84, 217, 0.15);
 }
 
@@ -113,17 +117,33 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
-h1 { font-size: 48px; font-weight: 600; letter-spacing: -0.02em; line-height: 1.1; }
-h2 { font-size: 32px; font-weight: 600; letter-spacing: -0.015em; line-height: 1.15; }
-h3 { font-size: 20px; font-weight: 500; letter-spacing: -0.01em; line-height: 1.2; }
+h1 {
+  font-size: 48px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+}
+h2 {
+  font-size: 32px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  line-height: 1.15;
+}
+h3 {
+  font-size: 20px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+}
 
-code, pre {
+code,
+pre {
   font-family: "Geist Mono", ui-monospace, monospace;
 }
 
 @theme inline {
   --font-heading: var(--font-sans);
-  --font-sans: 'Geist Variable', sans-serif;
+  --font-sans: "Geist Variable", sans-serif;
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/src/shared/ui/badge.tsx
+++ b/src/shared/ui/badge.tsx
@@ -1,8 +1,8 @@
-import { mergeProps } from "@base-ui/react/merge-props"
-import { useRender } from "@base-ui/react/use-render"
-import { cva, type VariantProps } from "class-variance-authority"
+import { mergeProps } from "@base-ui/react/merge-props";
+import { useRender } from "@base-ui/react/use-render";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "../lib/utils"
+import { cn } from "../lib/utils";
 
 const badgeVariants = cva(
   "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
@@ -10,22 +10,19 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
-        secondary:
-          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
         destructive:
           "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
-        outline:
-          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
-        ghost:
-          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        outline: "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost: "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
         link: "text-primary underline-offset-4 hover:underline",
       },
     },
     defaultVariants: {
       variant: "default",
     },
-  }
-)
+  },
+);
 
 function Badge({
   className,
@@ -39,14 +36,14 @@ function Badge({
       {
         className: cn(badgeVariants({ variant }), className),
       },
-      props
+      props,
     ),
     render,
     state: {
       slot: "badge",
       variant,
     },
-  })
+  });
 }
 
-export { Badge, badgeVariants }
+export { Badge, badgeVariants };

--- a/src/shared/ui/button.tsx
+++ b/src/shared/ui/button.tsx
@@ -1,7 +1,7 @@
-import { Button as ButtonPrimitive } from "@base-ui/react/button"
-import { cva, type VariantProps } from "class-variance-authority"
+import { Button as ButtonPrimitive } from "@base-ui/react/button";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "../lib/utils"
+import { cn } from "../lib/utils";
 
 const buttonVariants = cva(
   "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
@@ -37,8 +37,8 @@ const buttonVariants = cva(
       variant: "default",
       size: "default",
     },
-  }
-)
+  },
+);
 
 function Button({
   className,
@@ -52,7 +52,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/src/shared/ui/card.tsx
+++ b/src/shared/ui/card.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "../lib/utils"
+import { cn } from "../lib/utils";
 
 function Card({
   className,
@@ -13,11 +13,11 @@ function Card({
       data-size={size}
       className={cn(
         "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
@@ -26,11 +26,11 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-header"
       className={cn(
         "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
@@ -39,11 +39,11 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-title"
       className={cn(
         "font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
@@ -53,20 +53,17 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("text-sm text-muted-foreground", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardAction({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-action"
-      className={cn(
-        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
-        className
-      )}
+      className={cn("col-start-2 row-span-2 row-start-1 self-start justify-self-end", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardContent({ className, ...props }: React.ComponentProps<"div">) {
@@ -76,7 +73,7 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("px-4 group-data-[size=sm]/card:px-3", className)}
       {...props}
     />
-  )
+  );
 }
 
 function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
@@ -85,19 +82,11 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="card-footer"
       className={cn(
         "flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export {
-  Card,
-  CardHeader,
-  CardFooter,
-  CardTitle,
-  CardAction,
-  CardDescription,
-  CardContent,
-}
+export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent };

--- a/src/shared/ui/dialog.tsx
+++ b/src/shared/ui/dialog.tsx
@@ -1,42 +1,39 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
+import * as React from "react";
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
 
-import { cn } from "../lib/utils"
-import { Button } from "./button"
-import { XIcon } from "lucide-react"
+import { cn } from "../lib/utils";
+import { Button } from "./button";
+import { XIcon } from "lucide-react";
 
 function Dialog({ ...props }: DialogPrimitive.Root.Props) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
 function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 }
 
 function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 }
 
 function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
-  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
-function DialogOverlay({
-  className,
-  ...props
-}: DialogPrimitive.Backdrop.Props) {
+function DialogOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props) {
   return (
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
         "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DialogContent({
@@ -45,7 +42,7 @@ function DialogContent({
   showCloseButton = true,
   ...props
 }: DialogPrimitive.Popup.Props & {
-  showCloseButton?: boolean
+  showCloseButton?: boolean;
 }) {
   return (
     <DialogPortal>
@@ -54,7 +51,7 @@ function DialogContent({
         data-slot="dialog-content"
         className={cn(
           "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
-          className
+          className,
         )}
         {...props}
       >
@@ -62,32 +59,21 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            render={
-              <Button
-                variant="ghost"
-                className="absolute top-2 right-2"
-                size="icon-sm"
-              />
-            }
+            render={<Button variant="ghost" className="absolute top-2 right-2" size="icon-sm" />}
           >
-            <XIcon
-            />
+            <XIcon />
             <span className="sr-only">Close</span>
           </DialogPrimitive.Close>
         )}
       </DialogPrimitive.Popup>
     </DialogPortal>
-  )
+  );
 }
 
 function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
-    <div
-      data-slot="dialog-header"
-      className={cn("flex flex-col gap-2", className)}
-      {...props}
-    />
-  )
+    <div data-slot="dialog-header" className={cn("flex flex-col gap-2", className)} {...props} />
+  );
 }
 
 function DialogFooter({
@@ -96,54 +82,46 @@ function DialogFooter({
   children,
   ...props
 }: React.ComponentProps<"div"> & {
-  showCloseButton?: boolean
+  showCloseButton?: boolean;
 }) {
   return (
     <div
       data-slot="dialog-footer"
       className={cn(
         "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
-        className
+        className,
       )}
       {...props}
     >
       {children}
       {showCloseButton && (
-        <DialogPrimitive.Close render={<Button variant="outline" />}>
-          Close
-        </DialogPrimitive.Close>
+        <DialogPrimitive.Close render={<Button variant="outline" />}>Close</DialogPrimitive.Close>
       )}
     </div>
-  )
+  );
 }
 
 function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn(
-        "font-heading text-base leading-none font-medium",
-        className
-      )}
+      className={cn("font-heading text-base leading-none font-medium", className)}
       {...props}
     />
-  )
+  );
 }
 
-function DialogDescription({
-  className,
-  ...props
-}: DialogPrimitive.Description.Props) {
+function DialogDescription({ className, ...props }: DialogPrimitive.Description.Props) {
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
       className={cn(
         "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -157,4 +135,4 @@ export {
   DialogPortal,
   DialogTitle,
   DialogTrigger,
-}
+};

--- a/src/shared/ui/input.tsx
+++ b/src/shared/ui/input.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import { Input as InputPrimitive } from "@base-ui/react/input"
+import * as React from "react";
+import { Input as InputPrimitive } from "@base-ui/react/input";
 
-import { cn } from "../lib/utils"
+import { cn } from "../lib/utils";
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (
@@ -10,11 +10,11 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       data-slot="input"
       className={cn(
         "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Input }
+export { Input };

--- a/src/shared/ui/separator.tsx
+++ b/src/shared/ui/separator.tsx
@@ -1,25 +1,21 @@
-"use client"
+"use client";
 
-import { Separator as SeparatorPrimitive } from "@base-ui/react/separator"
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
 
-import { cn } from "../lib/utils"
+import { cn } from "../lib/utils";
 
-function Separator({
-  className,
-  orientation = "horizontal",
-  ...props
-}: SeparatorPrimitive.Props) {
+function Separator({ className, orientation = "horizontal", ...props }: SeparatorPrimitive.Props) {
   return (
     <SeparatorPrimitive
       data-slot="separator"
       orientation={orientation}
       className={cn(
         "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Separator }
+export { Separator };

--- a/src/shared/ui/table.tsx
+++ b/src/shared/ui/table.tsx
@@ -1,30 +1,21 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "../lib/utils"
+import { cn } from "../lib/utils";
 
 function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (
-    <div
-      data-slot="table-container"
-      className="relative w-full overflow-x-auto"
-    >
+    <div data-slot="table-container" className="relative w-full overflow-x-auto">
       <table
         data-slot="table"
         className={cn("w-full caption-bottom text-sm", className)}
         {...props}
       />
     </div>
-  )
+  );
 }
 
 function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
-  return (
-    <thead
-      data-slot="table-header"
-      className={cn("[&_tr]:border-b", className)}
-      {...props}
-    />
-  )
+  return <thead data-slot="table-header" className={cn("[&_tr]:border-b", className)} {...props} />;
 }
 
 function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
@@ -34,20 +25,17 @@ function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
       className={cn("[&_tr:last-child]:border-0", className)}
       {...props}
     />
-  )
+  );
 }
 
 function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
   return (
     <tfoot
       data-slot="table-footer"
-      className={cn(
-        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
-        className
-      )}
+      className={cn("border-t bg-muted/50 font-medium [&>tr]:last:border-b-0", className)}
       {...props}
     />
-  )
+  );
 }
 
 function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
@@ -56,11 +44,11 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
       data-slot="table-row"
       className={cn(
         "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function TableHead({ className, ...props }: React.ComponentProps<"th">) {
@@ -69,46 +57,31 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
       data-slot="table-head"
       className={cn(
         "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function TableCell({ className, ...props }: React.ComponentProps<"td">) {
   return (
     <td
       data-slot="table-cell"
-      className={cn(
-        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0",
-        className
-      )}
+      className={cn("p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0", className)}
       {...props}
     />
-  )
+  );
 }
 
-function TableCaption({
-  className,
-  ...props
-}: React.ComponentProps<"caption">) {
+function TableCaption({ className, ...props }: React.ComponentProps<"caption">) {
   return (
     <caption
       data-slot="table-caption"
       className={cn("mt-4 text-sm text-muted-foreground", className)}
       {...props}
     />
-  )
+  );
 }
 
-export {
-  Table,
-  TableHeader,
-  TableBody,
-  TableFooter,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableCaption,
-}
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };

--- a/src/shared/ui/tabs.tsx
+++ b/src/shared/ui/tabs.tsx
@@ -1,26 +1,19 @@
-"use client"
+"use client";
 
-import { Tabs as TabsPrimitive } from "@base-ui/react/tabs"
-import { cva, type VariantProps } from "class-variance-authority"
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "../lib/utils"
+import { cn } from "../lib/utils";
 
-function Tabs({
-  className,
-  orientation = "horizontal",
-  ...props
-}: TabsPrimitive.Root.Props) {
+function Tabs({ className, orientation = "horizontal", ...props }: TabsPrimitive.Root.Props) {
   return (
     <TabsPrimitive.Root
       data-slot="tabs"
       data-orientation={orientation}
-      className={cn(
-        "group/tabs flex gap-2 data-horizontal:flex-col",
-        className
-      )}
+      className={cn("group/tabs flex gap-2 data-horizontal:flex-col", className)}
       {...props}
     />
-  )
+  );
 }
 
 const tabsListVariants = cva(
@@ -35,8 +28,8 @@ const tabsListVariants = cva(
     defaultVariants: {
       variant: "default",
     },
-  }
-)
+  },
+);
 
 function TabsList({
   className,
@@ -50,7 +43,7 @@ function TabsList({
       className={cn(tabsListVariants({ variant }), className)}
       {...props}
     />
-  )
+  );
 }
 
 function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
@@ -62,11 +55,11 @@ function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
         "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
         "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
@@ -76,7 +69,7 @@ function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
       className={cn("flex-1 text-sm outline-none", className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants };

--- a/src/shared/ui/toggle.tsx
+++ b/src/shared/ui/toggle.tsx
@@ -1,7 +1,7 @@
-import { Toggle as TogglePrimitive } from "@base-ui/react/toggle"
-import { cva, type VariantProps } from "class-variance-authority"
+import { Toggle as TogglePrimitive } from "@base-ui/react/toggle";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "../lib/utils"
+import { cn } from "../lib/utils";
 
 const toggleVariants = cva(
   "group/toggle inline-flex items-center justify-center gap-1 rounded-lg text-sm font-medium whitespace-nowrap transition-all outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted data-[state=on]:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
@@ -22,8 +22,8 @@ const toggleVariants = cva(
       variant: "default",
       size: "default",
     },
-  }
-)
+  },
+);
 
 function Toggle({
   className,
@@ -37,7 +37,7 @@ function Toggle({
       className={cn(toggleVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Toggle, toggleVariants }
+export { Toggle, toggleVariants };

--- a/src/shared/ui/tooltip.tsx
+++ b/src/shared/ui/tooltip.tsx
@@ -1,28 +1,19 @@
-"use client"
+"use client";
 
-import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
 
-import { cn } from "../lib/utils"
+import { cn } from "../lib/utils";
 
-function TooltipProvider({
-  delay = 0,
-  ...props
-}: TooltipPrimitive.Provider.Props) {
-  return (
-    <TooltipPrimitive.Provider
-      data-slot="tooltip-provider"
-      delay={delay}
-      {...props}
-    />
-  )
+function TooltipProvider({ delay = 0, ...props }: TooltipPrimitive.Provider.Props) {
+  return <TooltipPrimitive.Provider data-slot="tooltip-provider" delay={delay} {...props} />;
 }
 
 function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
-  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
 }
 
 function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
-  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
 }
 
 function TooltipContent({
@@ -34,10 +25,7 @@ function TooltipContent({
   children,
   ...props
 }: TooltipPrimitive.Popup.Props &
-  Pick<
-    TooltipPrimitive.Positioner.Props,
-    "align" | "alignOffset" | "side" | "sideOffset"
-  >) {
+  Pick<TooltipPrimitive.Positioner.Props, "align" | "alignOffset" | "side" | "sideOffset">) {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Positioner
@@ -51,7 +39,7 @@ function TooltipContent({
           data-slot="tooltip-content"
           className={cn(
             "z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
-            className
+            className,
           )}
           {...props}
         >
@@ -60,7 +48,7 @@ function TooltipContent({
         </TooltipPrimitive.Popup>
       </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>
-  )
+  );
 }
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/src/widgets/site-footer/theme-toggle.tsx
+++ b/src/widgets/site-footer/theme-toggle.tsx
@@ -1,10 +1,5 @@
 import { useState, useEffect } from "react";
-import {
-  type Theme,
-  getStoredTheme,
-  setTheme,
-  listenToSystemTheme,
-} from "../../shared/lib/theme";
+import { type Theme, getStoredTheme, setTheme, listenToSystemTheme } from "../../shared/lib/theme";
 
 const iconPaths: Record<Theme, string> = {
   system:
@@ -41,10 +36,8 @@ export function ThemeToggle() {
             justifyContent: "center",
             border: `1px solid ${current === theme ? "var(--w3-accent)" : "var(--w3-gray-300)"}`,
             borderRadius: 4,
-            background:
-              current === theme ? "var(--w3-accent-subtle)" : "transparent",
-            color:
-              current === theme ? "var(--w3-accent)" : "var(--w3-gray-700)",
+            background: current === theme ? "var(--w3-accent-subtle)" : "transparent",
+            color: current === theme ? "var(--w3-accent)" : "var(--w3-gray-700)",
             cursor: "pointer",
             transition: "all 0.2s",
           }}

--- a/src/widgets/site-header/index.tsx
+++ b/src/widgets/site-header/index.tsx
@@ -29,11 +29,7 @@ export function SiteHeader({ currentSection }: SiteHeaderProps) {
           textDecoration: "none",
         }}
       >
-        <img
-          src="/logo.png"
-          alt="w3-kit"
-          style={{ height: 28, width: 28, borderRadius: 6 }}
-        />
+        <img src="/logo.png" alt="w3-kit" style={{ height: 28, width: 28, borderRadius: 6 }} />
       </a>
       <nav style={{ display: "flex", gap: "8px", alignItems: "center" }}>
         {currentSection && currentSection !== "landing" && (
@@ -57,10 +53,7 @@ export function SiteHeader({ currentSection }: SiteHeaderProps) {
             href={link.href}
             style={{
               fontSize: 14,
-              color:
-                currentSection === link.section
-                  ? "var(--w3-gray-900)"
-                  : "var(--w3-gray-700)",
+              color: currentSection === link.section ? "var(--w3-gray-900)" : "var(--w3-gray-700)",
               textDecoration: "none",
               padding: "4px 12px",
               borderRadius: 4,


### PR DESCRIPTION
## Summary
- Reorders CI steps so `npm run build` runs before `npm run typecheck`
- `vite build` triggers the TanStack Start plugin which generates `src/routeTree.gen.ts` on disk
- Without this file present, `tsc --noEmit` fails because it can't resolve the route tree import