### PR TITLE
feat: subdomain routing for all sections

### DIFF
--- a/src/app/middleware.ts
+++ b/src/app/middleware.ts
@@ -1,13 +1,25 @@
-export function getSubdomain(host: string): string {
+const SUBDOMAINS = ["ui", "docs", "registry", "learn", "design"] as const;
+
+export type Subdomain = (typeof SUBDOMAINS)[number] | "landing";
+
+export function getSubdomain(host: string): Subdomain {
   const parts = host.split(".");
+
+  // Support local subdomain testing: ui.localhost:3000, docs.localhost:3000, etc.
   if (host.includes("localhost") || host.includes("127.0.0.1")) {
+    const localSub = parts[0];
+    if (SUBDOMAINS.includes(localSub as (typeof SUBDOMAINS)[number])) {
+      return localSub as Subdomain;
+    }
     return "landing";
   }
+
   if (parts.length >= 3) {
     const sub = parts[0];
-    if (["ui", "docs", "registry"].includes(sub)) {
-      return sub;
+    if (SUBDOMAINS.includes(sub as (typeof SUBDOMAINS)[number])) {
+      return sub as Subdomain;
     }
   }
+
   return "landing";
 }

--- a/src/pages/under-construction/ui/under-construction-layout.tsx
+++ b/src/pages/under-construction/ui/under-construction-layout.tsx
@@ -6,7 +6,7 @@ interface UnderConstructionLayoutProps {
   section: Section;
   title: string;
   description: string;
-  animation: ReactNode;
+  animation?: ReactNode;
 }
 
 export function UnderConstructionLayout({

--- a/src/routes/learn/index.tsx
+++ b/src/routes/learn/index.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { UnderConstructionLayout } from "../../pages/under-construction";
+
+export const Route = createFileRoute("/learn/")({
+  component: () => (
+    <UnderConstructionLayout
+      section="learn"
+      title="Learn"
+      description="Guides, recipes, and tutorials for web3 development."
+    />
+  ),
+});

--- a/src/routes/learn/route.tsx
+++ b/src/routes/learn/route.tsx
@@ -1,0 +1,5 @@
+import { createFileRoute, Outlet } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/learn")({
+  component: () => <Outlet />,
+});

--- a/src/shared/lib/theme.ts
+++ b/src/shared/lib/theme.ts
@@ -1,5 +1,5 @@
 export type Theme = "system" | "light" | "dark";
-export type Section = "landing" | "ui" | "docs" | "registry" | "design";
+export type Section = "landing" | "ui" | "docs" | "registry" | "design" | "learn";
 
 export const THEME_KEY = "w3-theme";
 export const THEME_ATTR = "data-theme";

--- a/src/widgets/site-header/index.tsx
+++ b/src/widgets/site-header/index.tsx
@@ -4,11 +4,43 @@ interface SiteHeaderProps {
   currentSection?: Section;
 }
 
+const DOMAIN = "w3-kit.com";
+
 const navLinks = [
-  { label: "UI", href: "/ui", section: "ui" as const },
-  { label: "Docs", href: "/docs", section: "docs" as const },
-  { label: "Registry", href: "/registry", section: "registry" as const },
+  { label: "UI", section: "ui" as const },
+  { label: "Docs", section: "docs" as const },
+  { label: "Registry", section: "registry" as const },
+  { label: "Learn", section: "learn" as const },
+  { label: "Design", section: "design" as const },
 ];
+
+function getSectionUrl(section: string): string {
+  if (typeof window === "undefined") return `/${section}`;
+  const host = window.location.host;
+  const protocol = window.location.protocol;
+
+  // Localhost: use subdomain.localhost:port
+  if (host.includes("localhost") || host.includes("127.0.0.1")) {
+    const port = window.location.port;
+    return `${protocol}//${section}.localhost${port ? `:${port}` : ""}`;
+  }
+
+  // Production: use subdomain.domain
+  return `${protocol}//${section}.${DOMAIN}`;
+}
+
+function getLandingUrl(): string {
+  if (typeof window === "undefined") return "/";
+  const host = window.location.host;
+  const protocol = window.location.protocol;
+
+  if (host.includes("localhost") || host.includes("127.0.0.1")) {
+    const port = window.location.port;
+    return `${protocol}//localhost${port ? `:${port}` : ""}`;
+  }
+
+  return `${protocol}//www.${DOMAIN}`;
+}
 
 export function SiteHeader({ currentSection }: SiteHeaderProps) {
   return (
@@ -22,7 +54,7 @@ export function SiteHeader({ currentSection }: SiteHeaderProps) {
       }}
     >
       <a
-        href="/"
+        href={getLandingUrl()}
         style={{
           display: "flex",
           alignItems: "center",
@@ -34,7 +66,7 @@ export function SiteHeader({ currentSection }: SiteHeaderProps) {
       <nav style={{ display: "flex", gap: "8px", alignItems: "center" }}>
         {currentSection && currentSection !== "landing" && (
           <a
-            href="/"
+            href={getLandingUrl()}
             style={{
               fontSize: 14,
               color: "var(--w3-gray-700)",
@@ -50,7 +82,7 @@ export function SiteHeader({ currentSection }: SiteHeaderProps) {
         {navLinks.map((link) => (
           <a
             key={link.section}
-            href={link.href}
+            href={getSectionUrl(link.section)}
             style={{
               fontSize: 14,
               color: currentSection === link.section ? "var(--w3-gray-900)" : "var(--w3-gray-700)",

--- a/vercel.json
+++ b/vercel.json
@@ -16,6 +16,16 @@
       "source": "/:path*",
       "has": [{ "type": "host", "value": "registry.w3-kit.com" }],
       "destination": "/registry/:path*"
+    },
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "learn.w3-kit.com" }],
+      "destination": "/learn/:path*"
+    },
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "design.w3-kit.com" }],
+      "destination": "/design/:path*"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add `learn.w3-kit.com` and `design.w3-kit.com` Vercel rewrites + DNS domains
- Refactor middleware with typed `SUBDOMAINS` array and `Subdomain` type
- Enable local subdomain testing (`ui.localhost:3000`, `docs.localhost:3000`, etc.)
- Update site header to navigate between subdomains with absolute URLs
- Add `/learn` route with under-construction page
- Make `animation` prop optional on `UnderConstructionLayout`
- Add `"learn"` to the `Section` type

## Test plan
- [x] Visit `ui.w3-kit.com`, `docs.w3-kit.com`, `registry.w3-kit.com`, `learn.w3-kit.com`, `design.w3-kit.com`
- [x] Verify nav links navigate between subdomains correctly
- [x] Test `ui.localhost:3000` locally
- [x] Verify `w3-kit.com` still serves the landing page

Closes #83, closes #78, closes #68