### PR TITLE
fix(#81): correct author attribution on docs guides (was dependabot[bot])

### DIFF
--- a/scripts/generate-learn-registry.ts
+++ b/scripts/generate-learn-registry.ts
@@ -22,16 +22,20 @@ const LEARN_REPO_URL = "https://github.com/w3-kit/learn.git";
 
 /**
  * Returns the directory that holds guides/recipes/docs subfolders, either
- * from the sibling repo (local dev) or by shallow-cloning the public learn
- * repo into .tmp-learn-mirror/ (CI without the sibling, e.g., Vercel).
- * Returns null if neither is available.
+ * from the sibling repo (local dev) or by cloning the public learn repo
+ * into .tmp-learn-mirror/ (CI without the sibling, e.g., Vercel).
+ *
+ * NOTE: full clone (no --depth) is required so getGitAuthor() can walk
+ * history back to the commit that introduced each guide. A shallow clone
+ * only sees the latest commit, which is usually a dependabot bump — that
+ * would attribute every guide to dependabot[bot].
  */
 function resolveLearnDir(): string | null {
   if (fs.existsSync(SIBLING_LEARN)) return SIBLING_LEARN;
   if (fs.existsSync(CLONE_LEARN)) return CLONE_LEARN;
   try {
     console.log(`  learn sibling not found, cloning ${LEARN_REPO_URL} into .tmp-learn-mirror/`);
-    execSync(`git clone --depth 1 --quiet ${LEARN_REPO_URL} "${CLONE_LEARN}"`, {
+    execSync(`git clone --quiet ${LEARN_REPO_URL} "${CLONE_LEARN}"`, {
       stdio: ["ignore", "ignore", "inherit"],
     });
     return fs.existsSync(CLONE_LEARN) ? CLONE_LEARN : null;


### PR DESCRIPTION
## Bug

Every guide on \`docs.w3-kit.com\` is attributed to \`dependabot[bot]\`. See e.g. https://docs.w3-kit.com/docs/guide/accounts-model.

## Root cause

\`scripts/generate-learn-registry.ts\` resolves a guide's author with:

\`\`\`
git log --diff-filter=A --format=%an -- <file>
\`\`\`

i.e. the author of the commit that *added* the file. PR #119 added an auto-clone of \`w3-kit/learn\` for Vercel CI using \`--depth 1\`. A shallow clone contains only the latest commit on \`main\` — currently \`a4a0988 dependabot[bot]: chore(deps): bump actions/setup-node from 4 to 6 (#52)\` — so every file appears to have been "added" by dependabot at the shallow boundary.

## Fix

Drop \`--depth 1\` for the learn clone. The repo is small (~50 commits, < 5 MB), so the extra cost is negligible, and \`git log\` now walks back to the real introducing commit.

ui and registry clones keep \`--depth 1\` — neither uses \`git log\`.

## Verified

Sibling removed, \`npm run generate\` ran with the auto-clone:

| File | Author resolved to |
|---|---|
| guides/cheatsheets/solidity-vs-rust.md | \`Raad05\` |
| guides/cheatsheets/token-standards.md | \`peter941221\` |
| 9 other guides | \`PetarStoev02\` |

Recipe \`author\` fields (read from \`meta.json\`) are unaffected and already correct (\`PetarStoev02\`).

Refs #81