### PR TITLE
chore: group react and react-dom dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,12 @@ updates:
         update-types:
           - "minor"
           - "patch"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Follow-up to #132 / #133.

## What

Adds a \`react\` group to \`.github/dependabot.yml\` so that future Dependabot updates for \`react\`, \`react-dom\`, \`@types/react\`, and \`@types/react-dom\` arrive as a single grouped PR instead of individual PRs.

## Why

These packages must be on the exact same version. A single-side bump caused #133 / a 5-day production outage. Pinning to exact versions (#132) makes the failure mode loud, but grouping the Dependabot PRs prevents it from happening at all.

## Test plan

No app behavior changes. The next Dependabot run will exercise the new group config; the change is observable via Dependabot's behavior, not via the app.