### PR TITLE
feat(#71): add compare page for w3-kit vs alternatives

### DIFF
--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -69,6 +69,7 @@ async function main() {
   const urls: string[] = [];
 
   urls.push(apexUrl("/"));
+  urls.push(apexUrl("/compare"));
 
   urls.push(subUrl("registry", "/"));
   urls.push(subUrl("registry", "/chains"));

--- a/src/pages/compare/index.ts
+++ b/src/pages/compare/index.ts
@@ -1,0 +1,1 @@
+export { ComparePage } from "./ui/compare-page";

--- a/src/pages/compare/model/alternatives.ts
+++ b/src/pages/compare/model/alternatives.ts
@@ -1,0 +1,102 @@
+import type { Alternative, FeatureRow } from "./types";
+
+export const ALTERNATIVES: Alternative[] = [
+  {
+    id: "scaffold-eth",
+    name: "scaffold-eth",
+    url: "https://scaffoldeth.io",
+    tagline: "EVM dapp starter from BuidlGuidl. Hardhat + Next.js + RainbowKit.",
+    useWhen: [
+      "You're prototyping an EVM dapp at a hackathon and want batteries included.",
+      "You want a deeply integrated Hardhat workflow with hot-reloaded contracts.",
+      "Your team is already comfortable with the BuidlGuidl ecosystem.",
+    ],
+    chooseW3Kit: [
+      "You need Solana support alongside EVM.",
+      "You want a typed component library you can drop into any React app, not a fixed starter template.",
+      "You want a chain/token registry as a standalone package (@w3-kit/registry).",
+    ],
+  },
+  {
+    id: "create-web3-dapp",
+    name: "create-web3-dapp",
+    url: "https://createweb3dapp.alchemy.com",
+    tagline: "Alchemy's create-X-app generator for web3 templates.",
+    useWhen: [
+      "You're building specifically on the Alchemy stack and want their SDK plumbed in by default.",
+      "You want a one-shot scaffolder rather than a long-term toolkit dependency.",
+    ],
+    chooseW3Kit: [
+      "You want a toolkit you can keep using as the project grows, not just a generator.",
+      "You want first-class Solana support and a typed registry.",
+      "You want components that work with any RPC or aggregator, not vendor-tied.",
+    ],
+  },
+  {
+    id: "thirdweb",
+    name: "thirdweb",
+    url: "https://thirdweb.com",
+    tagline: "Closed-ecosystem dApp SDK + hosted dashboard, paid services on top.",
+    useWhen: [
+      "You want a hosted dashboard with built-in analytics, payments, and managed infra.",
+      "You're comfortable depending on their hosted services for production traffic.",
+      "Their pre-built smart contract deployments fit your needs out of the box.",
+    ],
+    chooseW3Kit: [
+      "You want full self-hosting, no vendor lock-in, MIT-licensed everything.",
+      "You want the same component quality without a hosted dependency.",
+      "You'd rather pay for infra you control than per-call SaaS pricing.",
+    ],
+  },
+];
+
+export const FEATURES: FeatureRow[] = [
+  {
+    label: "License",
+    w3kit: "MIT",
+    values: { "scaffold-eth": "MIT", "create-web3-dapp": "MIT", thirdweb: "Mixed" },
+  },
+  {
+    label: "Pricing",
+    w3kit: "Free",
+    values: { "scaffold-eth": "Free", "create-web3-dapp": "Free", thirdweb: "Freemium" },
+  },
+  {
+    label: "Chain support",
+    w3kit: "EVM + Solana",
+    values: { "scaffold-eth": "EVM", "create-web3-dapp": "EVM", thirdweb: "EVM + Solana" },
+  },
+  {
+    label: "UI components",
+    w3kit: "50+ typed React",
+    values: {
+      "scaffold-eth": "Starter components",
+      "create-web3-dapp": "Limited",
+      thirdweb: "Comprehensive",
+    },
+  },
+  {
+    label: "Chain registry",
+    w3kit: "Built-in package",
+    values: { "scaffold-eth": "Manual", "create-web3-dapp": "Manual", thirdweb: "Built-in" },
+  },
+  {
+    label: "Self-hosted",
+    w3kit: "Always",
+    values: { "scaffold-eth": "Always", "create-web3-dapp": "Always", thirdweb: "Optional" },
+  },
+  {
+    label: "Vendor lock-in",
+    w3kit: "None",
+    values: { "scaffold-eth": "None", "create-web3-dapp": "None", thirdweb: "Some" },
+  },
+  {
+    label: "CLI",
+    w3kit: "npx w3-kit add",
+    values: {
+      "scaffold-eth": "npm scripts",
+      "create-web3-dapp": "create-web3-dapp generator",
+      thirdweb: "thirdweb CLI",
+    },
+  },
+];

--- a/src/pages/compare/model/types.ts
+++ b/src/pages/compare/model/types.ts
@@ -1,0 +1,16 @@
+export type AlternativeId = "scaffold-eth" | "create-web3-dapp" | "thirdweb";
+
+export type Alternative = {
+  id: AlternativeId;
+  name: string;
+  url: string;
+  tagline: string;
+  useWhen: string[];
+  chooseW3Kit: string[];
+};
+
+export type FeatureRow = {
+  label: string;
+  w3kit: string;
+  values: Record<AlternativeId, string>;
+};

--- a/src/pages/compare/ui/alternative-card.tsx
+++ b/src/pages/compare/ui/alternative-card.tsx
@@ -1,0 +1,51 @@
+import { ArrowUpRight } from "lucide-react";
+import type { Alternative } from "../model/types";
+
+export function AlternativeCard({ alternative }: { alternative: Alternative }) {
+  return (
+    <article className="flex flex-col gap-5 rounded-xl border border-w3-border-subtle p-6">
+      <header>
+        <div className="flex items-center justify-between gap-3">
+          <h3 className="text-xl font-medium tracking-[-0.02em]">{alternative.name}</h3>
+          <a
+            href={alternative.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 font-mono text-[11px] text-w3-gray-500 hover:text-w3-accent"
+          >
+            Visit <ArrowUpRight size={11} />
+          </a>
+        </div>
+        <p className="mt-1 text-[13px] text-w3-gray-600">{alternative.tagline}</p>
+      </header>
+
+      <section>
+        <h4 className="text-[11px] font-medium uppercase tracking-[0.06em] text-w3-gray-500">
+          Use {alternative.name} when
+        </h4>
+        <ul className="mt-2 space-y-1.5 text-sm text-w3-gray-700">
+          {alternative.useWhen.map((bullet, i) => (
+            <li key={i} className="flex gap-2">
+              <span className="text-w3-gray-400">·</span>
+              <span>{bullet}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h4 className="text-[11px] font-medium uppercase tracking-[0.06em] text-w3-accent">
+          Choose w3-kit when
+        </h4>
+        <ul className="mt-2 space-y-1.5 text-sm text-w3-gray-900">
+          {alternative.chooseW3Kit.map((bullet, i) => (
+            <li key={i} className="flex gap-2">
+              <span className="text-w3-accent">·</span>
+              <span>{bullet}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </article>
+  );
+}

--- a/src/pages/compare/ui/compare-page.tsx
+++ b/src/pages/compare/ui/compare-page.tsx
@@ -1,0 +1,46 @@
+import { SiteHeader } from "../../../widgets/site-header";
+import { SiteFooter } from "../../../widgets/site-footer";
+import { ComparisonMatrix } from "./comparison-matrix";
+import { AlternativeCard } from "./alternative-card";
+import { ALTERNATIVES, FEATURES } from "../model/alternatives";
+
+export function ComparePage() {
+  return (
+    <div className="flex min-h-screen flex-col overflow-x-hidden bg-w3-gray-100 text-w3-gray-900 antialiased">
+      <SiteHeader currentSection="landing" />
+      <main className="flex-1 px-20 py-16">
+        <header className="mx-auto max-w-5xl">
+          <div className="font-mono text-[11px] text-w3-gray-500">COMPARE</div>
+          <h1 className="mt-2 text-[44px] font-medium leading-tight tracking-[-0.03em]">
+            w3-kit vs alternatives.
+          </h1>
+          <p className="mt-3 max-w-prose text-w3-gray-600">
+            An honest comparison. Pick the toolkit that fits your project &mdash; sometimes that's
+            not w3-kit, and we'll tell you when.
+          </p>
+        </header>
+
+        <section className="mx-auto mt-12 max-w-5xl">
+          <h2 className="text-sm font-medium uppercase tracking-[0.06em] text-w3-gray-500">
+            Feature matrix
+          </h2>
+          <div className="mt-4">
+            <ComparisonMatrix alternatives={ALTERNATIVES} features={FEATURES} />
+          </div>
+        </section>
+
+        <section className="mx-auto mt-16 max-w-5xl">
+          <h2 className="text-sm font-medium uppercase tracking-[0.06em] text-w3-gray-500">
+            When to pick each one
+          </h2>
+          <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-3">
+            {ALTERNATIVES.map((a) => (
+              <AlternativeCard key={a.id} alternative={a} />
+            ))}
+          </div>
+        </section>
+      </main>
+      <SiteFooter />
+    </div>
+  );
+}

--- a/src/pages/compare/ui/comparison-matrix.tsx
+++ b/src/pages/compare/ui/comparison-matrix.tsx
@@ -1,0 +1,58 @@
+import type { Alternative, FeatureRow } from "../model/types";
+
+export function ComparisonMatrix({
+  alternatives,
+  features,
+}: {
+  alternatives: Alternative[];
+  features: FeatureRow[];
+}) {
+  return (
+    <div className="overflow-x-auto rounded-xl border border-w3-border-subtle">
+      <table className="w-full border-collapse text-sm">
+        <thead>
+          <tr className="border-b border-w3-border-subtle bg-w3-surface-alt">
+            <th scope="col" className="px-4 py-3 text-left font-medium text-w3-gray-500">
+              Feature
+            </th>
+            <th
+              scope="col"
+              className="border-l border-w3-accent/20 bg-w3-accent-wash px-4 py-3 text-left font-medium text-w3-accent"
+            >
+              w3-kit
+            </th>
+            {alternatives.map((a) => (
+              <th
+                key={a.id}
+                scope="col"
+                className="border-l border-w3-border-subtle px-4 py-3 text-left font-medium text-w3-gray-700"
+              >
+                {a.name}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {features.map((row) => (
+            <tr key={row.label} className="border-b border-w3-border-subtle last:border-0">
+              <th scope="row" className="px-4 py-3 text-left font-medium text-w3-gray-700">
+                {row.label}
+              </th>
+              <td className="border-l border-w3-accent/20 bg-w3-accent-wash/40 px-4 py-3 font-medium text-w3-gray-900">
+                {row.w3kit}
+              </td>
+              {alternatives.map((a) => (
+                <td
+                  key={a.id}
+                  className="border-l border-w3-border-subtle px-4 py-3 text-w3-gray-700"
+                >
+                  {row.values[a.id]}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/routes/_landing/compare.tsx
+++ b/src/routes/_landing/compare.tsx
@@ -1,0 +1,27 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { ComparePage } from "../../pages/compare";
+import { buildMeta } from "../../shared/lib/seo";
+
+const seo = buildMeta({
+  title: "w3-kit vs Alternatives — Honest Comparison",
+  description:
+    "An honest comparison of w3-kit against scaffold-eth, create-web3-dapp, and thirdweb. Pick the toolkit that fits your project.",
+  path: "/compare",
+});
+
+const jsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  name: "w3-kit vs Alternatives",
+  description: "Honest comparison of w3-kit against scaffold-eth, create-web3-dapp, and thirdweb.",
+  url: "https://w3-kit.com/compare",
+});
+
+export const Route = createFileRoute("/_landing/compare")({
+  head: () => ({
+    meta: seo.meta,
+    links: seo.links,
+    scripts: [{ type: "application/ld+json", children: jsonLd }],
+  }),
+  component: ComparePage,
+});

--- a/tests/compare.spec.ts
+++ b/tests/compare.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Compare page", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" });
+  });
+
+  test("renders hero, matrix, and alternative cards", async ({ page }) => {
+    await page.goto("/compare");
+    await expect(page.getByRole("heading", { name: /w3-kit vs alternatives/i })).toBeVisible();
+
+    await expect(page.getByRole("columnheader", { name: "w3-kit" })).toBeVisible();
+    await expect(page.getByRole("columnheader", { name: "scaffold-eth" })).toBeVisible();
+    await expect(page.getByRole("columnheader", { name: "create-web3-dapp" })).toBeVisible();
+    await expect(page.getByRole("columnheader", { name: "thirdweb" })).toBeVisible();
+
+    await expect(page.getByRole("row", { name: /Chain support/i })).toContainText("EVM + Solana");
+
+    for (const name of ["scaffold-eth", "create-web3-dapp", "thirdweb"]) {
+      const card = page.getByRole("article").filter({ hasText: name });
+      await expect(card.getByText(`Use ${name} when`)).toBeVisible();
+      await expect(card.getByText(/Choose w3-kit when/i)).toBeVisible();
+    }
+  });
+
+  test("alternative links open in new tab and are safe", async ({ page }) => {
+    await page.goto("/compare");
+    const links = page.getByRole("link", { name: /^Visit/ });
+    const count = await links.count();
+    expect(count).toBeGreaterThanOrEqual(3);
+    for (let i = 0; i < count; i++) {
+      const link = links.nth(i);
+      await expect(link).toHaveAttribute("target", "_blank");
+      await expect(link).toHaveAttribute("rel", /noopener/);
+    }
+  });
+
+  test("has SEO title and canonical", async ({ page }) => {
+    await page.goto("/compare");
+    await expect(page).toHaveTitle(/vs|Comparison/i);
+    const canonical = await page.locator('link[rel="canonical"]').getAttribute("href");
+    expect(canonical).toMatch(/\/compare$/);
+  });
+});


### PR DESCRIPTION
Closes #71.

## Summary
- New \`/compare\` page on the main domain
- Feature matrix: w3-kit + scaffold-eth + create-web3-dapp + thirdweb across 8 honest categories
- Per-alternative cards with "Use [X] when" and "Choose w3-kit when" sections
- SEO meta + JSON-LD \`WebPage\` schema
- Added to sitemap

## Test plan
- [x] \`npx playwright test tests/compare.spec.ts\` (3 tests, all pass)
- [x] \`npm run typecheck\`, \`npm run lint\`, \`npm run format:check\` clean
- [ ] Manual review of comparison data for tone and factual accuracy

## Notes
- The comparison data is opinionated by design but tries to be fair. "Choose w3-kit when" bullets are factual differentiators, not promotional. All in \`src/pages/compare/model/alternatives.ts\` for easy iteration.
- External alternative URLs verified at write time; if any have changed, update in \`alternatives.ts\`.

## Out of scope
- Visitor-submitted alternatives or feedback
- Dynamic / interactive matrix filtering
- Side-by-side code snippets per alternative